### PR TITLE
Optional ignore patters for relative imports rule

### DIFF
--- a/lib/rules/relative-imports.js
+++ b/lib/rules/relative-imports.js
@@ -68,7 +68,7 @@ module.exports = {
     
     // Get ignores from rule options (preferred) or fallback to settings
     const ignorePatterns = options.ignores || 
-      context.settings['feature-sliced-design-imports/layers']?.ignores || 
+      context.settings['feature-sliced-design-imports/relative-imports']?.ignores || 
       [];
 
     const layers = getLayers(layersConfig);

--- a/lib/rules/relative-imports.js
+++ b/lib/rules/relative-imports.js
@@ -12,6 +12,24 @@ const {
 } = require('../helpers');
 const { getLayers } = require('../constants');
 
+// Use minimatch for glob pattern matching (common in ESLint ecosystem)
+let minimatch;
+try {
+  minimatch = require('minimatch');
+} catch (e) {
+  // Fallback to a simple glob implementation if minimatch is not available
+  console.log('Using fallback glob matcher');
+  minimatch = (path, pattern) => {
+    // Simple glob implementation supporting * and **
+    const regexPattern = pattern
+      .replace(/\*\*/g, '.*')
+      .replace(/\*/g, '[^/]*')
+      .replace(/\?/g, '.')
+      .replace(/\./g, '\\.');
+    return new RegExp(`^${regexPattern}$`).test(path);
+  };
+}
+
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
@@ -22,28 +40,76 @@ module.exports = {
       url: null,
     },
     fixable: null,
-    schema: [{}],
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          ignores: {
+            type: 'array',
+            items: {
+              type: 'string'
+            },
+            description: 'Array of glob patterns to ignore'
+          }
+        },
+        additionalProperties: false
+      }
+    ],
     messages: {
       shouldBeRelativePath: 'Path should be relative!',
     },
   },
 
   create(context) {
+    const options = context.options[0] || {};
     const alias = context.settings['feature-sliced-design-imports/alias'] || '';
     const layersConfig =
       context.settings['feature-sliced-design-imports/layers'] || {};
+    
+    // Get ignores from rule options (preferred) or fallback to settings
+    const ignorePatterns = options.ignores || 
+      context.settings['feature-sliced-design-imports/layers']?.ignores || 
+      [];
 
     const layers = getLayers(layersConfig);
 
-    function shouldBeRelative(currectFilePath, importPath) {
+    function shouldBeRelative(currentFilePath, importPath) {
+      // Check if the current file (where the import is happening) matches any ignore pattern
+      if (ignorePatterns.length > 0) {
+        const isFileIgnored = ignorePatterns.some(pattern => {
+          try {
+            if (typeof pattern === 'string') {
+              // Normalize the file path for pattern matching
+              const normalizedFilePath = currentFilePath.replace(/\\/g, '/');
+              const relativePath = normalizedFilePath.replace(/^.*\/kmbs-front\//, '');
+              
+              // Use glob matching to check if file should be ignored
+              return minimatch(relativePath, pattern);
+            } else if (pattern && typeof pattern.test === 'function') {
+              // Legacy regex support
+              return pattern.test(currentFilePath);
+            }
+            return false;
+          } catch (e) {
+            console.warn(`Invalid ignore pattern: ${pattern}`, e);
+            return false;
+          }
+        });
+        
+        if (isFileIgnored) {
+          return false;
+        }
+      }
+
       if (isPathRelative(importPath)) return false;
 
       // entities/Article
       const [importLayer, importSlice] = extractLayerAndSlice(importPath)
+
       if (!importLayer || !importSlice || !layers[importLayer]) return false;
 
-      // C:\Users\dev\Desktop\project\src\entities\Article
-      const [fileLayer, fileSlice] = extractLayerAndSlice(formatCurrentFilePath(currectFilePath));
+      const [fileLayer, fileSlice] = extractLayerAndSlice(formatCurrentFilePath(currentFilePath));
+
       if (!fileLayer || !fileSlice || !layers[fileLayer])  return false;
 
       return importSlice === fileSlice && importLayer === fileLayer;
@@ -54,7 +120,7 @@ module.exports = {
         try {
           const importPath = removeAliasFromImport(node.source.value, alias);
 
-          if (shouldBeRelative(context.filename, importPath)) {
+          if (shouldBeRelative(context.filename || context.getFilename(), importPath)) {
             context.report({ node, messageId: 'shouldBeRelativePath' });
           }
         } catch (e) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-plugin-feature-sliced-design-imports",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-plugin-feature-sliced-design-imports",
-      "version": "1.0.3",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "micromatch": "^4.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-plugin-feature-sliced-design-imports",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-plugin-feature-sliced-design-imports",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "MIT",
       "dependencies": {
         "micromatch": "^4.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-feature-sliced-design-imports",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A custom ESLint plugin designed to enforce strict import rules in projects following the Feature-Sliced Design architecture.",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -53,5 +53,8 @@
   "peerDependencies": {
     "eslint": ">=8.57.0"
   },
+  "optionalDependencies": {
+    "minimatch": "^10"
+  },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-feature-sliced-design-imports",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A custom ESLint plugin designed to enforce strict import rules in projects following the Feature-Sliced Design architecture.",
   "keywords": [
     "eslint",


### PR DESCRIPTION
Adds "ignores" option to the "feature-sliced-design-imports/relative-imports" settings. The setting is optional. Allows to bypass files following user-specified glob-patters.

Usage example:

```ts
import { defineConfig } from "eslint/config";
import { dirname } from "path";
import { fileURLToPath } from "url";
import { FlatCompat } from "@eslint/eslintrc";

const __filename = fileURLToPath(import.meta.url);
const __dirname = dirname(__filename);

const compat = new FlatCompat({
  baseDirectory: __dirname,
});

export default defineConfig([
  // Configuration for source files
  ...compat.config({
    plugins: ["feature-sliced-design-imports"],
    settings: {
      "feature-sliced-design-imports/relative-imports": {
        ignores: ["src/shared/ui/components/stories/**"], // ignore storybook stories
      },
    },
    rules: {
      "feature-sliced-design-imports/layer-imports": "error",
      "feature-sliced-design-imports/relative-imports": "error",
      "feature-sliced-design-imports/public-api-imports": "error",
    },
  }),
]);


```